### PR TITLE
fix: click outside click issue

### DIFF
--- a/packages/react-native/src/components/survey-web-view.tsx
+++ b/packages/react-native/src/components/survey-web-view.tsx
@@ -147,6 +147,7 @@ export function SurveyWebView(
                 appUrl: appConfig.get().appUrl,
                 clickOutside:
                   surveyPlacement === "center" ? clickOutside : true,
+                ignorePlacementForClickOutside: true,
                 darkOverlay,
                 getSetIsResponseSendingFinished: (
                   _f: (value: boolean) => void

--- a/packages/react-native/src/types/survey.ts
+++ b/packages/react-native/src/types/survey.ts
@@ -45,6 +45,7 @@ export interface SurveyBaseProps {
   isCardBorderVisible?: boolean;
   startAtQuestionId?: string;
   clickOutside?: boolean;
+  ignorePlacementForClickOutside?: boolean;
   darkOverlay?: boolean;
   hiddenFieldsRecord?: TResponseData;
   shouldResetQuestionId?: boolean;


### PR DESCRIPTION
Fixes #13 
This includes adding a prop to the surveys package that ignore the placement `center` check in the close outside click logic. Makes the survey modal close when clicking outside unless the user specifically restricted it by setting placement to center and disallowing click outside close in the survey. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional setting to control click outside behavior in surveys, allowing for more flexible interaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->