### PR TITLE
fix: adds permissions for id-token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Release React Native SDK
 
 permissions:
+  id-token: write
   contents: read
+
 on:
   release:
     types: [published]


### PR DESCRIPTION
adds the write permission to `id-token` in the release github action for working with the `--provenance` flag in the `npm publish` command