### PR TITLE
fix: fixes repo url

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://formbricks.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/formbricks/formbricks"
+    "url": "https://github.com/formbricks/react-native"
   },
   "keywords": [
     "Formbricks",


### PR DESCRIPTION
changes the repository url in the react-native package to `formbricks/react-native`, which is the correct one instead of `formbricks/formbricks`