### PR TITLE
feat: add onSetup Prop to the Formbricks component

### DIFF
--- a/packages/react-native/src/components/formbricks.tsx
+++ b/packages/react-native/src/components/formbricks.tsx
@@ -22,14 +22,22 @@ export function Formbricks({
 	useEffect(() => {
 		const setupFormbricks = async (): Promise<void> => {
 			try {
-				await setup({
+				const result = await setup({
 					environmentId,
 					appUrl,
 				});
 
-				onSetup?.();
-			} catch {
-				logger.debug("Initialization failed");
+				if (result.ok) {
+					onSetup?.();
+				} else {
+					logger.error(`Initialization failed: ${String(result.error)}`);
+				}
+			} catch (err) {
+				logger.error(
+					`Initialization threw: ${
+						err instanceof Error ? err?.message : String(err)
+					}`
+				);
 			}
 		};
 


### PR DESCRIPTION
This PR introduces a new optional prop onSetup to the Formbricks React Native component.

The onSetup callback is executed once the SDK initialization (init) is completed successfully. This allows developers to trigger custom logic on mobile apps after ensuring that Formbricks is fully set up.

Motivation

On mobile, certain flows require confirmation that the SDK is ready before proceeding (e.g., starting surveys, syncing data, or updating UI state). Without this hook, there was no straightforward way to guarantee that init had finished.

Changes

Added a new prop:

onSetup?: () => void;


Invoked onSetup after successful init completion in the setup flow.

Example Usage
<Formbricks
  appUrl={APP_URL}
  environmentId={ENV_ID}
  onSetup={() => {
    console.log("Formbricks initialized, ready to run custom logic");
  }}
/>

Impact

Backwards compatible (prop is optional).

Enables mobile developers to reliably run code after Formbricks initialization.