### PR TITLE
fix: upgrade vite to latest stable version 7.1.7

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -51,7 +51,7 @@
     "react": "19.0.0",
     "react-native": "0.79.4",
     "terser": "5.37.0",
-    "vite": "7.0.7",
+    "vite": "7.1.7",
     "vite-plugin-dts": "4.5.4",
     "vitest": "3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,11 +89,11 @@ importers:
         specifier: 5.37.0
         version: 5.37.0
       vite:
-        specifier: 7.0.7
-        version: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+        specifier: 7.1.7
+        version: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
+        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
@@ -2547,6 +2547,15 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4243,6 +4252,10 @@ packages:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4465,8 +4478,8 @@ packages:
       vite:
         optional: true
 
-  vite@7.0.7:
-    resolution: {integrity: sha512-hc6LujN/EkJHmxeiDJMs0qBontZ1cdBvvoCbWhVjzUFTU329VRyOC46gHNSA8NcOC5yzCeXpwI40tieI3DEZqg==}
+  vite@7.1.7:
+    resolution: {integrity: sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6454,13 +6467,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))':
+  '@vitest/mocker@3.2.4(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7728,7 +7741,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
-  fdir@6.4.6(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
@@ -9670,6 +9683,11 @@ snapshots:
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
@@ -9872,7 +9890,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9887,7 +9905,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)):
+  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)):
     dependencies:
       '@microsoft/api-extractor': 7.52.8(@types/node@24.0.10)
       '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
@@ -9900,20 +9918,20 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.3
     optionalDependencies:
-      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0):
+  vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0):
     dependencies:
       esbuild: 0.25.5
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.44.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.0.10
       fsevents: 2.3.3
@@ -9924,7 +9942,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9942,7 +9960,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       vite-node: 3.2.4(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Description

This PR upgrades Vite from version 7.0.0 to 7.1.7 (latest stable) to address security vulnerabilities flagged by Dependabot and ensure we're using the most up-to-date version.

## Changes

- 🔧 Updates `vite` dependency from `7.0.0` to `7.1.7` (latest stable) in `packages/react-native/package.json`
- 📦 Updates corresponding entries in `pnpm-lock.yaml`

## Why This Change

- Fixes dependabot security warnings related to Vite
- Upgrades to the latest stable version (7.1.7) for maximum security and stability
- Includes all security patches and improvements from versions 7.0.1 through 7.1.7
- No breaking changes expected as this is within the same major version

## Testing

- ✅ Dependencies updated successfully
- ✅ No breaking changes in the build process
- ✅ All existing functionality remains intact
- ✅ Uses latest stable version with all security patches

## Type of Change

- [x] Security update (latest stable version)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Changes have been tested locally
- [x] Code follows the existing style guidelines
- [x] Dependencies are up to date with latest stable version
- [x] No new vulnerabilities introduced
- [x] All security patches included