### PR TITLE
[Backport] fix: upgrade vite to latest stable version 7.1.7

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -51,7 +51,7 @@
     "react": "19.0.0",
     "react-native": "0.79.4",
     "terser": "5.37.0",
-    "vite": "7.0.7",
+    "vite": "7.1.7",
     "vite-plugin-dts": "4.5.4",
     "vitest": "3.2.4"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -51,7 +51,7 @@
     "react": "19.0.0",
     "react-native": "0.79.4",
     "terser": "5.37.0",
-    "vite": "7.0.0",
+    "vite": "7.0.7",
     "vite-plugin-dts": "4.5.4",
     "vitest": "3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,11 +89,11 @@ importers:
         specifier: 5.37.0
         version: 5.37.0
       vite:
-        specifier: 7.0.0
-        version: 7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+        specifier: 7.0.7
+        version: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
+        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
@@ -3629,6 +3629,10 @@ packages:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -4461,8 +4465,8 @@ packages:
       vite:
         optional: true
 
-  vite@7.0.0:
-    resolution: {integrity: sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==}
+  vite@7.0.7:
+    resolution: {integrity: sha512-hc6LujN/EkJHmxeiDJMs0qBontZ1cdBvvoCbWhVjzUFTU329VRyOC46gHNSA8NcOC5yzCeXpwI40tieI3DEZqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6398,7 +6402,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint@8.57.0)(typescript@5.8.3)
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.0)(typescript@5.8.3)
       eslint-config-prettier: 9.1.0(eslint@8.57.0)
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.32.0)
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0))
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0)
       eslint-plugin-eslint-comments: 3.2.0(eslint@8.57.0)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
@@ -6450,13 +6454,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))':
+  '@vitest/mocker@3.2.4(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7333,7 +7337,7 @@ snapshots:
     dependencies:
       eslint: 8.57.0
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)):
     dependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
 
@@ -7360,7 +7364,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7388,7 +7392,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7723,6 +7727,10 @@ snapshots:
   fdir@6.4.6(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.4.6(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -8924,6 +8932,8 @@ snapshots:
 
   picomatch@4.0.2: {}
 
+  picomatch@4.0.3: {}
+
   pirates@4.0.7: {}
 
   pkg-types@1.3.1:
@@ -9862,7 +9872,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9877,7 +9887,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)):
+  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)):
     dependencies:
       '@microsoft/api-extractor': 7.52.8(@types/node@24.0.10)
       '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
@@ -9890,17 +9900,17 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.3
     optionalDependencies:
-      vite: 7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0):
+  vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0):
     dependencies:
       esbuild: 0.25.5
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.44.2
       tinyglobby: 0.2.14
@@ -9914,7 +9924,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
+      '@vitest/mocker': 3.2.4(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9932,7 +9942,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.0(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       vite-node: 3.2.4(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,11 +89,11 @@ importers:
         specifier: 5.37.0
         version: 5.37.0
       vite:
-        specifier: 7.0.7
-        version: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+        specifier: 7.1.7
+        version: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
+        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
@@ -2547,6 +2547,15 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4243,6 +4252,10 @@ packages:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
   tinypool@1.1.1:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -4465,8 +4478,8 @@ packages:
       vite:
         optional: true
 
-  vite@7.0.7:
-    resolution: {integrity: sha512-hc6LujN/EkJHmxeiDJMs0qBontZ1cdBvvoCbWhVjzUFTU329VRyOC46gHNSA8NcOC5yzCeXpwI40tieI3DEZqg==}
+  vite@7.1.7:
+    resolution: {integrity: sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6454,13 +6467,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))':
+  '@vitest/mocker@3.2.4(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7728,7 +7741,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
-  fdir@6.4.6(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
@@ -9670,6 +9683,11 @@ snapshots:
       fdir: 6.4.6(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
   tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
@@ -9872,7 +9890,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9887,7 +9905,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)):
+  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)):
     dependencies:
       '@microsoft/api-extractor': 7.52.8(@types/node@24.0.10)
       '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
@@ -9900,20 +9918,20 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.3
     optionalDependencies:
-      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0):
+  vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0):
     dependencies:
       esbuild: 0.25.5
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.44.2
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.0.10
       fsevents: 2.3.3
@@ -9924,7 +9942,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9942,7 +9960,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       vite-node: 3.2.4(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Backport PR to release/2.3.0

This is a backport of the Vite upgrade to the latest stable version (7.1.7) to the `release/2.3.0` branch to ensure the released version also receives all security fixes and improvements.

## Original PR
Main branch PR: #30

## Description

This PR backports the Vite upgrade from version 7.0.0 to 7.1.7 (latest stable) to address security vulnerabilities flagged by Dependabot.

## Changes

- 🔧 Updates `vite` dependency from `7.0.0` to `7.1.7` (latest stable) in `packages/react-native/package.json`
- 📦 Updates corresponding entries in `pnpm-lock.yaml`

## Why This Backport

- Fixes dependabot security warnings in the released 2.3.0 branch
- Ensures users of version 2.3.0 get the latest stable version with all security fixes
- Includes all security patches and improvements from versions 7.0.1 through 7.1.7
- Critical security patches should be backported to stable release branches

## Security Impact

- Addresses all known vulnerabilities in Vite 7.0.0
- Includes latest security patches from stable releases 7.0.1-7.1.7
- No functional changes, only security improvements and bug fixes
- Safe to merge into release branch as it's within the same major version

## Type of Change

- [x] Security update (latest stable backport)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] This is a clean backport of latest stable version
- [x] No breaking changes introduced
- [x] Changes have been tested locally
- [x] Dependencies are compatible with release branch
- [x] All security patches included