### PR TITLE
chore(deps): update vite to 7.1.9

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -51,7 +51,7 @@
     "react": "19.0.0",
     "react-native": "0.79.4",
     "terser": "5.37.0",
-    "vite": "7.1.7",
+    "vite": "7.1.9",
     "vite-plugin-dts": "4.5.4",
     "vitest": "3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,11 +89,11 @@ importers:
         specifier: 5.37.0
         version: 5.37.0
       vite:
-        specifier: 7.1.7
-        version: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+        specifier: 7.1.9
+        version: 7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       vite-plugin-dts:
         specifier: 4.5.4
-        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
+        version: 4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
       vitest:
         specifier: 3.2.4
         version: 3.2.4(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
@@ -2539,14 +2539,6 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
-  fdir@6.4.6:
-    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
-    peerDependencies:
-      picomatch: ^3 || ^4
-    peerDependenciesMeta:
-      picomatch:
-        optional: true
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -4478,8 +4470,8 @@ packages:
       vite:
         optional: true
 
-  vite@7.1.7:
-    resolution: {integrity: sha512-VbA8ScMvAISJNJVbRDTJdCwqQoAareR/wutevKanhR2/1EkoXVZVkkORaYm/tNVCjP/UDTKtcw3bAkwOUdedmA==}
+  vite@7.1.9:
+    resolution: {integrity: sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6026,7 +6018,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.2
+      picomatch: 4.0.3
     optionalDependencies:
       rollup: 4.44.2
 
@@ -6467,13 +6459,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))':
+  '@vitest/mocker@3.2.4(vite@7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7370,7 +7362,7 @@ snapshots:
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       unrs-resolver: 1.11.0
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
@@ -7736,10 +7728,6 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
-
-  fdir@6.4.6(picomatch@4.0.2):
-    optionalDependencies:
-      picomatch: 4.0.2
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -9446,7 +9434,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.2
       sort-object-keys: 1.1.3
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
 
   source-map-js@1.2.1: {}
 
@@ -9680,8 +9668,8 @@ snapshots:
 
   tinyglobby@0.2.14:
     dependencies:
-      fdir: 6.4.6(picomatch@4.0.2)
-      picomatch: 4.0.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
 
   tinyglobby@0.2.15:
     dependencies:
@@ -9890,7 +9878,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9905,7 +9893,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)):
+  vite-plugin-dts@4.5.4(@types/node@24.0.10)(rollup@4.44.2)(typescript@5.8.3)(vite@7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)):
     dependencies:
       '@microsoft/api-extractor': 7.52.8(@types/node@24.0.10)
       '@rollup/pluginutils': 5.2.0(rollup@4.44.2)
@@ -9918,13 +9906,13 @@ snapshots:
       magic-string: 0.30.17
       typescript: 5.8.3
     optionalDependencies:
-      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0):
+  vite@7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0):
     dependencies:
       esbuild: 0.25.5
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9942,7 +9930,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
+      '@vitest/mocker': 3.2.4(vite@7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9960,7 +9948,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.7(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
+      vite: 7.1.9(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       vite-node: 3.2.4(@types/node@24.0.10)(lightningcss@1.27.0)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Summary
Update Vite from 7.1.7 to 7.1.9 to resolve PandaBot security alerts.

## Changes
- Updated `vite` dependency to version 7.1.9 in `packages/react-native/package.json`
- Updated related dependencies in `pnpm-lock.yaml`

## Reason
This update addresses security vulnerabilities identified by PandaBot alerts.