### PR TITLE
chore: bumps react native package version

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formbricks/react-native",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "description": "Formbricks React Native SDK allows you to connect your app to Formbricks, display surveys and trigger events.",
   "homepage": "https://formbricks.com",


### PR DESCRIPTION
Bumps the version of the react-native package to `2.3.1` for the release