### PR TITLE
fix: override @xmldom/xmldom to resolve XML injection vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "typescript": "6.0.2",
     "rimraf": "6.1.3"
   },
+  "pnpm": {
+    "overrides": {
+      "@xmldom/xmldom": "0.9.10"
+    }
+  },
   "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@xmldom/xmldom': 0.9.10
+
 importers:
 
   .:
@@ -1386,10 +1389,9 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
-  '@xmldom/xmldom@0.8.11':
-    resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
-    engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -4181,7 +4183,7 @@ snapshots:
 
   '@expo/plist@0.5.2':
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.9.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -4745,7 +4747,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.11': {}
+  '@xmldom/xmldom@0.9.10': {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -6079,7 +6081,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.11
+      '@xmldom/xmldom': 0.9.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
## Summary
- Resolves high severity security alert: **xmldom XML injection via unsafe CDATA serialization** (`@xmldom/xmldom@0.8.11`)
- Adds `pnpm.overrides` to force `@xmldom/xmldom` to `>=0.9.10` (patched version)
- Both `plist@3.1.0` and `@expo/plist@0.5.2` pin to `^0.8.8`, which under semver for `0.x` packages won't resolve to `0.9.x` — the override is needed to bridge this

## Test plan
- [x] `pnpm install` succeeds, lockfile resolves `@xmldom/xmldom` to `0.9.10` for all consumers
- [x] All 145 tests pass
- [ ] Verify the GitHub security alert is resolved after merge

Resolves ENG-799

🤖 Generated with [Claude Code](https://claude.com/claude-code)