### PR TITLE
fix: [Backport] fixes language comparing in react-native sdk

### DIFF
--- a/packages/react-native/src/lib/common/tests/utils.test.ts
+++ b/packages/react-native/src/lib/common/tests/utils.test.ts
@@ -453,6 +453,17 @@ describe("utils.ts", () => {
       expect(getLanguageCode(survey, "fr")).toBe("fr");
       expect(getLanguageCode(survey, "fr-FR")).toBe("fr");
     });
+
+    test("matches a region-tagged canonical code case-insensitively", () => {
+      const survey = {
+        languages: [
+          { language: { code: "en-US" }, default: true, enabled: true },
+          { language: { code: "de-DE" }, default: false, enabled: true },
+        ],
+      } as unknown as TSurvey;
+      // Canonical codes carry an uppercase region; the matcher must lowercase both sides.
+      expect(getLanguageCode(survey, "de-DE")).toBe("de-DE");
+    });
   });
 
   // ---------------------------------------------------------------------------------

--- a/packages/react-native/src/lib/common/utils.ts
+++ b/packages/react-native/src/lib/common/utils.ts
@@ -179,7 +179,7 @@ export const getLanguageCode = (
 
   const selectedLanguage = survey.languages.find((surveyLanguage) => {
     return (
-      surveyLanguage.language.code === language.toLowerCase() ||
+      surveyLanguage.language.code.toLowerCase() === language.toLowerCase() ||
       surveyLanguage.language.alias?.toLowerCase() === language.toLowerCase()
     );
   });


### PR DESCRIPTION
Backport of #67 