### PR TITLE
fix(security): escape survey WebView payload to prevent </script> injection (ENG-1813)

### DIFF
--- a/packages/react-native/src/components/survey-web-view.tsx
+++ b/packages/react-native/src/components/survey-web-view.tsx
@@ -336,6 +336,15 @@ const renderHtml = (
   `;
   }
 
+  // Escape "<" so survey content can't inject "</script>" (or "<script"/"<!--") and break
+  // out of the inline <script> below: "<" occurs only inside JSON string values, and the
+  // WebView's JS engine decodes the escaped "<" back to a literal "<" when parsing the
+  // object literal, so the payload is preserved exactly. See ENG-1813.
+  const optionsJson = JSON.stringify(options).replaceAll(
+    "<",
+    String.raw`\u003c`,
+  );
+
   return `
   <!doctype html>
   <html>
@@ -372,11 +381,7 @@ const renderHtml = (
       function getSetIsError() { /* noop */ };
 
       function loadSurvey() {
-        // Escape "<" so survey content can't inject "</script>" (or "<script"/"<!--") and
-        // break out of this inline script. "<" appears only inside JSON string values, and
-        // the JS engine decodes \\u003c back to "<" when parsing this object literal, so the
-        // payload is preserved exactly. See ENG-1813.
-        const options = ${JSON.stringify(options).replace(/</g, "\\u003c")};
+        const options = ${optionsJson};
         const surveyProps = {
           ...options,
           onDisplayCreated,

--- a/packages/react-native/src/components/survey-web-view.tsx
+++ b/packages/react-native/src/components/survey-web-view.tsx
@@ -372,7 +372,11 @@ const renderHtml = (
       function getSetIsError() { /* noop */ };
 
       function loadSurvey() {
-        const options = ${JSON.stringify(options)};
+        // Escape "<" so survey content can't inject "</script>" (or "<script"/"<!--") and
+        // break out of this inline script. "<" appears only inside JSON string values, and
+        // the JS engine decodes \\u003c back to "<" when parsing this object literal, so the
+        // payload is preserved exactly. See ENG-1813.
+        const options = ${JSON.stringify(options).replace(/</g, "\\u003c")};
         const surveyProps = {
           ...options,
           onDisplayCreated,


### PR DESCRIPTION
## What & why

**ENG-1813 — script injection via the survey WebView payload.**

`renderHtml` embeds the survey payload directly into an inline `<script>`:

```js
const options = ${JSON.stringify(options)};
```

`JSON.stringify` escapes `"` and `\`, so the classic string/backtick breakout is already prevented here — but it does **not** escape `<`. A survey field containing `</script>` (or `<script`, `<!--`) terminates the inline `<script>` at the HTML-parser level, regardless of JS string context, and injects arbitrary markup/JS into the WebView. The payload includes server/admin-authored survey content (`props.survey`, styling, …), so this is attacker-influenceable.

This is the React Native variant of the same ENG-1813 issue fixed on iOS (formbricks/ios#51) and Android (formbricks/android#55).

## Fix

Escape `<` → `<` in the serialized payload:

```js
const options = ${JSON.stringify(options).replace(/</g, "\\u003c")};
```

`<` only ever appears inside JSON string values (never in structural positions), and the JS engine decodes `<` back to `<` when parsing the object literal — so the payload is preserved exactly while `</script>` / `<script` / `<!--` can no longer form in the script's raw text.

Chose escaping over the iOS/Android base64 approach because React Native's JS runtime has no global `Buffer`/`btoa` (would need a polyfill); the escape is dependency-free, keeps `options` a plain object literal (no `JSON.parse` needed), and fully closes the `</script>` vector.

## Verification

- `tsc --noEmit` — clean.
- `vitest run` — 155/155 pass.
- Node check: a headline of `` `${alert(1)}` </script><img src=x onerror=alert(1)> `` produces output with no literal `</script>` (in fact no literal `<` at all) and round-trips to the exact original object.

## Notes / scope

- Part of a cross-SDK sweep of the iOS survey-WebView findings. iOS: formbricks/ios#51. Android equivalent: formbricks/android#55. Flutter was already safe.
- The other three checks were audited on this SDK and are already safe: TLS/MITM (relies on `react-native-webview` defaults — `onReceivedSslError` → `cancel()`), WebView debugging (`webviewDebuggingEnabled` never set; library gates it behind `DEBUG`), and external URL scheme (`openExternalUrl` already allowlists `http`/`https`).
