### PR TITLE
chore: bump to 3.1.0

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formbricks/react-native",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "license": "MIT",
   "description": "Formbricks React Native SDK allows you to connect your app to Formbricks, display surveys and trigger events.",
   "homepage": "https://formbricks.com",


### PR DESCRIPTION
Release prep for [#73](https://github.com/formbricks/react-native/pull/73).

## Why minor, not patch

**It adds a feature.** Survey-interaction segment filters ("have seen X", "have completed X", …) did not work on React Native before — the SDK kept using the segment list it received at app launch, so a rule like "completed survey A → show survey B" never fired in the same session.

**Workspaces using interaction targeting get new traffic.** An extra `POST /user` after a display, response or finish — gated per survey and per event, and routed through the UpdateQueue so a display → response → finish burst debounces into one request. Workspaces that don't use interaction targeting see no change at all, since the server omits the gate entirely for them.

Unlike the native SDKs, there was no dormant timer bug to fix here — `addUserStateExpiryCheckListener` *extends* `expiresAt` rather than refetching, matching `js-core`. So this release does not change baseline traffic for existing apps.

**No public API changed.** `src/index.ts` still exports exactly `track`, `setUserId`, `setAttribute`, `setAttributes`, `setLanguage`, `logout` and `Formbricks`. The new `interactionRefresh` field on `TSurvey` is an optional addition to a type that isn't exported, and `renderHtml` is exported from its module for tests but not re-exported from the entry point — `package.json`'s `exports` map is restricted to `.`, so it stays package-internal.

## Changes

- `packages/react-native/package.json`: `3.0.1` → `3.1.0`

The playground depends on `workspace:*`, so nothing else needs updating.

## Verification

`tsc --noEmit` clean, `biome check` clean, 170 tests passing.
