### PR TITLE
feat: setEmbeddedData() + clearEmbeddedData() for app surveys [ENG-2472]

### DIFF
--- a/packages/react-native/src/components/survey-web-view.tsx
+++ b/packages/react-native/src/components/survey-web-view.tsx
@@ -88,6 +88,14 @@ export function SurveyWebView(props: SurveyWebViewProps): JSX.Element | null {
       return;
     }
 
+    /**
+     * Shows the survey, taking the Embedded Data snapshot in the same update.
+     *
+     * Both calls belong together and in this order: React batches them into one render, so the
+     * WebView mounts with the bag already frozen rather than mounting empty and re-rendering with
+     * it — which would change `source` and reload the survey. Called directly, or from the delay
+     * timeout below, so the snapshot is always taken at the moment the survey actually appears.
+     */
     const display = (): void => {
       setEmbeddedDataSnapshot(EmbeddedDataStore.getInstance().getSnapshot());
       setShowSurvey(true);

--- a/packages/react-native/src/components/survey-web-view.tsx
+++ b/packages/react-native/src/components/survey-web-view.tsx
@@ -15,7 +15,7 @@ import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
 import { SurveyStore } from "@/lib/survey/store";
 import { refreshSegmentsAfterInteraction } from "@/lib/user/interaction-refresh";
 import { type TUserState, ZJsRNWebViewOnMessageData } from "@/types/config";
-import type { TResponseData } from "@/types/response";
+import type { TIngestedFieldsRecord } from "@/types/response";
 import type { SurveyContainerProps, TSurvey } from "@/types/survey";
 
 const logger = Logger.getInstance();
@@ -44,7 +44,7 @@ export function SurveyWebView(props: SurveyWebViewProps): JSX.Element | null {
    * js-core snapshots at too (it builds its own bag inside the delay timeout).
    */
   const [embeddedDataSnapshot, setEmbeddedDataSnapshot] =
-    useState<TResponseData>({});
+    useState<TIngestedFieldsRecord>({});
 
   useEffect(() => {
     const fetchConfig = async (): Promise<void> => {

--- a/packages/react-native/src/components/survey-web-view.tsx
+++ b/packages/react-native/src/components/survey-web-view.tsx
@@ -11,9 +11,11 @@ import { getSurveyScriptUrl } from "@/components/utils/survey-script-url";
 import { RNConfig } from "@/lib/common/config";
 import { Logger } from "@/lib/common/logger";
 import { filterSurveys, getLanguageCode, getStyling } from "@/lib/common/utils";
+import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
 import { SurveyStore } from "@/lib/survey/store";
 import { refreshSegmentsAfterInteraction } from "@/lib/user/interaction-refresh";
 import { type TUserState, ZJsRNWebViewOnMessageData } from "@/types/config";
+import type { TResponseData } from "@/types/response";
 import type { SurveyContainerProps, TSurvey } from "@/types/survey";
 
 const logger = Logger.getInstance();
@@ -31,6 +33,18 @@ export function SurveyWebView(props: SurveyWebViewProps): JSX.Element | null {
   const [showSurvey, setShowSurvey] = useState(false);
   const [appConfig, setAppConfig] = useState<RNConfig | null>(null);
   const [languageCode, setLanguageCode] = useState("default");
+  /**
+   * The Embedded Data bag, snapshotted at the moment the survey is shown and frozen for the rest of
+   * its life (ENG-1844). Held in state rather than read inline in the render pass on purpose: the
+   * html string below is an *input* to the WebView, so reading a mutable bag while rendering would
+   * let a later `setEmbeddedData` rewrite `source` and reload the WebView mid-survey — losing the
+   * respondent's answers. A later write therefore reaches the next response, never this one.
+   *
+   * Set in the same update as `setShowSurvey(true)`, which is the delay-aware display moment
+   * js-core snapshots at too (it builds its own bag inside the delay timeout).
+   */
+  const [embeddedDataSnapshot, setEmbeddedDataSnapshot] =
+    useState<TResponseData>({});
 
   useEffect(() => {
     const fetchConfig = async (): Promise<void> => {
@@ -74,20 +88,23 @@ export function SurveyWebView(props: SurveyWebViewProps): JSX.Element | null {
       return;
     }
 
+    const display = (): void => {
+      setEmbeddedDataSnapshot(EmbeddedDataStore.getInstance().getSnapshot());
+      setShowSurvey(true);
+    };
+
     if (props.survey.delay) {
       logger.debug(
         `Delaying survey "${props.survey.id}" by ${String(props.survey.delay)} seconds`,
       );
-      const timerId = setTimeout(() => {
-        setShowSurvey(true);
-      }, props.survey.delay * 1000);
+      const timerId = setTimeout(display, props.survey.delay * 1000);
 
       return () => {
         clearTimeout(timerId);
       };
     }
 
-    setShowSurvey(true);
+    display();
   }, [props.survey.delay, isSurveyRunning, props.survey.id]);
 
   if (!appConfig) {
@@ -152,6 +169,11 @@ export function SurveyWebView(props: SurveyWebViewProps): JSX.Element | null {
                 clickOutside,
                 overlay,
                 isWebEnvironment: false,
+                // Passed straight through, unfiltered: the Embedded Data ingest contract lives in
+                // the renderer (ENG-1845/2472), so all four mobile SDKs inherit the same allow-list,
+                // coercion and size rules without each shipping a copy. The renderer drops unknown
+                // and locked keys and logs what it refused; the server re-runs all of it on ingest.
+                hiddenFieldsRecord: embeddedDataSnapshot,
               }),
             }}
             style={styles.webView}

--- a/packages/react-native/src/components/tests/survey-web-view-harness.test.ts
+++ b/packages/react-native/src/components/tests/survey-web-view-harness.test.ts
@@ -44,6 +44,26 @@ describe("WebView harness", () => {
     expect(propsBlock).toContain("onClose,");
   });
 
+  /**
+   * The Embedded Data bag (ENG-1844/2472) rides the props blob that already exists — no new bridge
+   * message. The blob is JSON, so this pins that the key survives serialization under the name the
+   * renderer reads, with the SDK doing no filtering of its own: the renderer owns the allow-list.
+   */
+  test("carries hiddenFieldsRecord into the payload, raw and unfiltered", () => {
+    const html = renderHtml({
+      appUrl: "https://app.formbricks.com",
+      workspaceId: "ws-1",
+      hiddenFieldsRecord: {
+        plan: "pro",
+        notDeclaredBySurvey: "kept — the renderer decides, not the SDK",
+      },
+    });
+
+    expect(html).toContain('"hiddenFieldsRecord":{');
+    expect(html).toContain('"plan":"pro"');
+    expect(html).toContain('"notDeclaredBySurvey"');
+  });
+
   test("still escapes < in the payload so survey content cannot break out of the script", () => {
     const html = renderHtml({
       appUrl: "https://app.formbricks.com",

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -1,6 +1,10 @@
 import { CommandQueue } from "@/lib/common/command-queue";
 import { Logger } from "@/lib/common/logger";
 import * as Actions from "@/lib/survey/action";
+import {
+  EmbeddedDataStore,
+  type TEmbeddedDataInput,
+} from "@/lib/survey/embedded-data";
 import * as Attributes from "@/lib/user/attribute";
 import * as User from "@/lib/user/user";
 
@@ -41,6 +45,34 @@ export const setLanguage = async (language: string): Promise<void> => {
 export const logout = async (): Promise<void> => {
   queue.add(User.logout, true);
   await queue.wait();
+};
+
+/**
+ * Attach Embedded Data to future responses without tying it to a trigger (ENG-1844). Merges into the
+ * in-memory bag, last write wins per key; `{ key: null }` removes a key and `undefined` values are
+ * skipped. Values land only on the survey's declared *ingested* fields — anything else is dropped
+ * and logged by the renderer, never fatal.
+ *
+ * Synchronous and network-free on purpose, unlike the queued methods above: calling it on every
+ * screen change is free, and routing it through the command queue would silently drop calls made
+ * before `setup()` completes — a host legitimately pushes context before the SDK is ready.
+ *
+ * ```ts
+ * setEmbeddedData({ screen: "checkout", plan: "pro" });
+ * setEmbeddedData({ screen: null }); // remove one key
+ * ```
+ */
+export const setEmbeddedData = (data: TEmbeddedDataInput): void => {
+  EmbeddedDataStore.getInstance().setEmbeddedData(data);
+};
+
+/**
+ * Remove one Embedded Data key, or clear the whole bag when called with no argument — logout, or a
+ * hard context switch. Synchronous, no network. A key that evaluated to `undefined` is a no-op, not
+ * a full clear: the arity is forwarded, so only a literal zero-argument call wipes everything.
+ */
+export const clearEmbeddedData = (...args: [] | [key: string]): void => {
+  EmbeddedDataStore.getInstance().clearEmbeddedData(...args);
 };
 
 export { Formbricks, Formbricks as default } from "@/components/formbricks";

--- a/packages/react-native/src/lib/survey/embedded-data.ts
+++ b/packages/react-native/src/lib/survey/embedded-data.ts
@@ -1,5 +1,5 @@
 import { Logger } from "@/lib/common/logger";
-import type { TResponseData } from "@/types/response";
+import type { TIngestedFieldsRecord } from "@/types/response";
 
 /** What a host app may hand to `setEmbeddedData`. `null` removes the key; `undefined` is a no-op. */
 export type TEmbeddedDataInput = Record<
@@ -66,6 +66,17 @@ export class EmbeddedDataStore {
         this.data.delete(key);
         continue;
       }
+      // Refused rather than stored: `toISOString()` throws a RangeError on an invalid Date, and
+      // `getSnapshot` runs inside the effect that displays the survey — so one `new Date("nope")`
+      // from host code would cost the survey, not the field. This guard exists here and not in
+      // js-core because serializing the Date is this SDK's own step: js-core hands the Date object
+      // straight to the renderer, which coerces it. Never fatal, always logged.
+      if (value instanceof Date && Number.isNaN(value.getTime())) {
+        Logger.getInstance().error(
+          `setEmbeddedData: "${key}" is an invalid Date — the key was skipped`,
+        );
+        continue;
+      }
       this.data.set(key, value);
     }
   }
@@ -101,15 +112,18 @@ export class EmbeddedDataStore {
    *
    * Dates are serialized here rather than at the JSON boundary: `renderHtml` stringifies the props
    * blob, and an ISO 8601 string is exactly what the renderer's ingest contract accepts for a `date`
-   * field. The cast is the same one js-core makes — the contract accepts boolean and date scalars
-   * that the narrower legacy `hiddenFields` type cannot spell, and normalizes them before storage.
+   * field. `setEmbeddedData` refuses an invalid Date, so `toISOString` here cannot throw.
+   *
+   * The return type spells booleans rather than asserting them away: the bag really does hold them,
+   * the renderer's contract really does accept them, and only the legacy `TResponseData` could not
+   * say so.
    */
-  public getSnapshot(): TResponseData {
+  public getSnapshot(): TIngestedFieldsRecord {
     return Object.fromEntries(
       Array.from(this.data, ([key, value]) => [
         key,
         value instanceof Date ? value.toISOString() : value,
       ]),
-    ) as TResponseData;
+    );
   }
 }

--- a/packages/react-native/src/lib/survey/embedded-data.ts
+++ b/packages/react-native/src/lib/survey/embedded-data.ts
@@ -1,0 +1,115 @@
+import { Logger } from "@/lib/common/logger";
+import type { TResponseData } from "@/types/response";
+
+/** What a host app may hand to `setEmbeddedData`. `null` removes the key; `undefined` is a no-op. */
+export type TEmbeddedDataInput = Record<
+  string,
+  string | number | boolean | Date | null | undefined
+>;
+
+/**
+ * The in-memory Embedded Data bag (ENG-1844/2472): context a host app attaches to future responses
+ * without tying it to a trigger — `setEmbeddedData({ screen: "checkout" })` once, instead of
+ * repeating the same values on every possible `track()` call. Mirrors js-core's store so the web and
+ * mobile SDKs behave identically, key for key.
+ *
+ * Lifetime rules, all deliberate:
+ *
+ * - **In-memory, process scoped, never persisted.** Not `RNConfig`: that class writes to async
+ *   storage, and persisting this bag would blur the Embedded Data ↔ contact-attribute boundary and
+ *   create a stale-data / PII-at-rest surface. A cold app start begins empty; the host re-pushes.
+ * - **Snapshot at display, then frozen.** `SurveyWebView` copies the bag into the survey's
+ *   `hiddenFieldsRecord` when the survey is shown; a later `setEmbeddedData` affects the next
+ *   response, never the one on screen.
+ * - **No filtering here.** The SDK is a dumb pipe: the renderer applies the ingest contract —
+ *   allow-list, coercion, `locked`, size caps — and logs what it refuses, and the server re-runs all
+ *   of it on ingest. Filtering here would ship a second copy of those rules for the four mobile SDKs
+ *   to drift from.
+ * - **No network.** Every method is a synchronous memory write, so calling `setEmbeddedData` on
+ *   every screen change is free. Values ride the existing response payload.
+ *
+ * Backed by a `Map` rather than a plain object so a `__proto__` key is stored as data instead of
+ * vanishing into the prototype — the same hole the ingest contract closes on the renderer side.
+ */
+export class EmbeddedDataStore {
+  private static instance: EmbeddedDataStore | undefined;
+  private data = new Map<string, string | number | boolean | Date>();
+
+  static getInstance(): EmbeddedDataStore {
+    EmbeddedDataStore.instance ??= new EmbeddedDataStore();
+    return EmbeddedDataStore.instance;
+  }
+
+  /**
+   * Merge — never replace — so refreshing a volatile field (`screen`) cannot wipe the stable ones
+   * (`plan`) set at launch. Per key: last write wins; `null` removes; `undefined` does nothing.
+   *
+   * The `undefined` no-op is a documented promise, not an accident: a host that builds the object
+   * from its own state passes every field unconditionally, so a key that is absent on the current
+   * screen arrives as `undefined` and must not clear the value a previous screen set.
+   */
+  public setEmbeddedData(data: TEmbeddedDataInput): void {
+    // Guarded rather than thrown: this is a synchronous entry point outside the command queue's
+    // shield, and a host can legitimately hand over a value that was not there. A broken host build
+    // is a worse failure than a skipped write. An array is refused too (`typeof [] === "object"`):
+    // it would spread into junk numeric keys ({0: "a", 1: "b"}).
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+      Logger.getInstance().error(
+        `setEmbeddedData: expected an object, got ${data === null ? "null" : typeof data} — nothing was set`,
+      );
+      return;
+    }
+
+    for (const [key, value] of Object.entries(data)) {
+      if (value === undefined) continue;
+      if (value === null) {
+        this.data.delete(key);
+        continue;
+      }
+      this.data.set(key, value);
+    }
+  }
+
+  /**
+   * Remove one key, or everything when called with no argument (logout / hard context switch).
+   *
+   * "No argument" and "an argument that evaluated to `undefined`" are deliberately different: a host
+   * reading the key from its own state must not wipe the whole bag when that state is empty, so
+   * only a literal zero-argument call clears everything.
+   */
+  public clearEmbeddedData(...args: [] | [key: string]): void {
+    if (args.length === 0) {
+      this.data.clear();
+      return;
+    }
+
+    const [key] = args;
+    if (typeof key !== "string") {
+      Logger.getInstance().error(
+        "clearEmbeddedData: expected a field name — nothing was cleared (call with no argument to clear everything)",
+      );
+      return;
+    }
+
+    this.data.delete(key);
+  }
+
+  /**
+   * A detached copy for the display-time snapshot: mutating the bag after a survey rendered must not
+   * reach that survey's response. `Object.fromEntries` defines own properties, so a `__proto__` key
+   * survives the conversion as data.
+   *
+   * Dates are serialized here rather than at the JSON boundary: `renderHtml` stringifies the props
+   * blob, and an ISO 8601 string is exactly what the renderer's ingest contract accepts for a `date`
+   * field. The cast is the same one js-core makes — the contract accepts boolean and date scalars
+   * that the narrower legacy `hiddenFields` type cannot spell, and normalizes them before storage.
+   */
+  public getSnapshot(): TResponseData {
+    return Object.fromEntries(
+      Array.from(this.data, ([key, value]) => [
+        key,
+        value instanceof Date ? value.toISOString() : value,
+      ]),
+    ) as TResponseData;
+  }
+}

--- a/packages/react-native/src/lib/survey/embedded-data.ts
+++ b/packages/react-native/src/lib/survey/embedded-data.ts
@@ -33,7 +33,7 @@ export type TEmbeddedDataInput = Record<
  */
 export class EmbeddedDataStore {
   private static instance: EmbeddedDataStore | undefined;
-  private data = new Map<string, string | number | boolean | Date>();
+  private readonly data = new Map<string, string | number | boolean | Date>();
 
   static getInstance(): EmbeddedDataStore {
     EmbeddedDataStore.instance ??= new EmbeddedDataStore();

--- a/packages/react-native/src/lib/survey/embedded-data.ts
+++ b/packages/react-native/src/lib/survey/embedded-data.ts
@@ -60,10 +60,14 @@ export class EmbeddedDataStore {
       return;
     }
 
+    const set: string[] = [];
+    const removed: string[] = [];
+
     for (const [key, value] of Object.entries(data)) {
       if (value === undefined) continue;
       if (value === null) {
         this.data.delete(key);
+        removed.push(key);
         continue;
       }
       // Refused rather than stored: `toISOString()` throws a RangeError on an invalid Date, and
@@ -78,7 +82,17 @@ export class EmbeddedDataStore {
         continue;
       }
       this.data.set(key, value);
+      set.push(key);
     }
+
+    // A success trace, because the bag is otherwise invisible: it lives in memory (nothing in async
+    // storage to inspect) and the API has no getter, so without this line a developer wiring up
+    // `setEmbeddedData` gets zero confirmation until a survey happens to display. Debug level, which
+    // this SDK gates on `__DEV__`, so a release build never prints it. Keys only, never values — the
+    // documented use of this bag includes hashed identity fields.
+    Logger.getInstance().debug(
+      `setEmbeddedData: set [${set.join(", ")}]${removed.length > 0 ? `, removed [${removed.join(", ")}]` : ""} — the bag now holds [${[...this.data.keys()].join(", ")}]. Keys land on a response only if the survey declares them as ingested Embedded Data fields.`,
+    );
   }
 
   /**
@@ -90,7 +104,11 @@ export class EmbeddedDataStore {
    */
   public clearEmbeddedData(...args: [] | [key: string]): void {
     if (args.length === 0) {
+      const clearedCount = this.data.size;
       this.data.clear();
+      Logger.getInstance().debug(
+        `clearEmbeddedData: cleared the whole bag (${String(clearedCount)} keys)`,
+      );
       return;
     }
 
@@ -103,6 +121,9 @@ export class EmbeddedDataStore {
     }
 
     this.data.delete(key);
+    Logger.getInstance().debug(
+      `clearEmbeddedData: removed "${key}" — the bag now holds [${[...this.data.keys()].join(", ")}]`,
+    );
   }
 
   /**

--- a/packages/react-native/src/lib/survey/embedded-data.ts
+++ b/packages/react-native/src/lib/survey/embedded-data.ts
@@ -90,8 +90,10 @@ export class EmbeddedDataStore {
     // `setEmbeddedData` gets zero confirmation until a survey happens to display. Debug level, which
     // this SDK gates on `__DEV__`, so a release build never prints it. Keys only, never values — the
     // documented use of this bag includes hashed identity fields.
+    const removedSegment =
+      removed.length > 0 ? `, removed [${removed.join(", ")}]` : "";
     Logger.getInstance().debug(
-      `setEmbeddedData: set [${set.join(", ")}]${removed.length > 0 ? `, removed [${removed.join(", ")}]` : ""} — the bag now holds [${[...this.data.keys()].join(", ")}]. Keys land on a response only if the survey declares them as ingested Embedded Data fields.`,
+      `setEmbeddedData: set [${set.join(", ")}]${removedSegment} — the bag now holds [${[...this.data.keys()].join(", ")}]. Keys land on a response only if the survey declares them as ingested Embedded Data fields.`,
     );
   }
 

--- a/packages/react-native/src/lib/survey/tests/embedded-data.test.ts
+++ b/packages/react-native/src/lib/survey/tests/embedded-data.test.ts
@@ -1,9 +1,14 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
 
-// The guards log through Logger; mocked so refused inputs don't spray the test output.
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { error: vi.fn(), debug: vi.fn() },
+}));
+
+// The guards log errors and the success trace logs at debug; mocked so refused inputs don't spray
+// the test output, and a stable instance lets the trace tests below assert on what was written.
 vi.mock("@/lib/common/logger", () => ({
-  Logger: { getInstance: vi.fn(() => ({ error: vi.fn(), debug: vi.fn() })) },
+  Logger: { getInstance: vi.fn(() => mockLogger) },
 }));
 
 type TSetInput = Parameters<EmbeddedDataStore["setEmbeddedData"]>[0];
@@ -164,5 +169,69 @@ describe("input guards (never fatal)", () => {
     store.clearEmbeddedData(undefined as unknown as string);
 
     expect(store.getSnapshot()).toEqual({ plan: "pro", screen: "product" });
+  });
+});
+
+describe("the debug success trace — the bag's only success feedback", () => {
+  let store: EmbeddedDataStore;
+
+  beforeEach(() => {
+    store = EmbeddedDataStore.getInstance();
+    store.clearEmbeddedData();
+    mockLogger.debug.mockClear();
+  });
+
+  test("a successful set logs the keys it set and what the bag now holds — keys only, never values", () => {
+    store.setEmbeddedData({ plan: "pro", hashed_email: "s3cret-hash" });
+
+    expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+    const message = mockLogger.debug.mock.calls[0][0] as string;
+    expect(message).toContain("set [plan, hashed_email]");
+    expect(message).toContain("the bag now holds [plan, hashed_email]");
+    // The bag's documented use includes hashed identity fields; values must never reach a log line.
+    expect(message).not.toContain("pro");
+    expect(message).not.toContain("s3cret-hash");
+  });
+
+  test("a null removal shows up in the trace as removed, not set", () => {
+    store.setEmbeddedData({ plan: "pro" });
+    mockLogger.debug.mockClear();
+
+    store.setEmbeddedData({ plan: null, screen: "product" });
+
+    const message = mockLogger.debug.mock.calls[0][0] as string;
+    expect(message).toContain("set [screen]");
+    expect(message).toContain("removed [plan]");
+    expect(message).toContain("the bag now holds [screen]");
+  });
+
+  test("a skipped invalid Date appears in neither list, and its value never reaches the log", () => {
+    store.setEmbeddedData({ plan: "pro", signedUpAt: new Date("nope") });
+
+    const message = mockLogger.debug.mock.calls[0][0] as string;
+    expect(message).toContain("set [plan]");
+    expect(message).not.toContain("signedUpAt");
+  });
+
+  test("clearEmbeddedData traces both forms", () => {
+    store.setEmbeddedData({ plan: "pro", screen: "product" });
+    mockLogger.debug.mockClear();
+
+    store.clearEmbeddedData("plan");
+    expect(mockLogger.debug.mock.calls[0][0]).toContain('removed "plan"');
+
+    store.clearEmbeddedData();
+    expect(mockLogger.debug.mock.calls[1][0]).toContain(
+      "cleared the whole bag (1 keys)",
+    );
+  });
+
+  test("a refused input logs an error and no success trace", () => {
+    mockLogger.error.mockClear();
+
+    store.setEmbeddedData(null as unknown as TSetInput);
+
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    expect(mockLogger.debug).not.toHaveBeenCalled();
   });
 });

--- a/packages/react-native/src/lib/survey/tests/embedded-data.test.ts
+++ b/packages/react-native/src/lib/survey/tests/embedded-data.test.ts
@@ -80,6 +80,27 @@ describe("EmbeddedDataStore", () => {
     });
   });
 
+  test("an invalid Date is refused rather than costing the survey", () => {
+    // THE guard: `toISOString()` throws a RangeError on an invalid Date, and `getSnapshot` runs
+    // inside the effect that displays the survey — so storing one would mean no survey at all,
+    // not a missing field.
+    store.setEmbeddedData({ plan: "pro" });
+
+    store.setEmbeddedData({ signedUpAt: new Date("not a date") });
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro" });
+    expect(() => store.getSnapshot()).not.toThrow();
+  });
+
+  test("a valid Date alongside an invalid one still lands", () => {
+    store.setEmbeddedData({
+      good: new Date("2026-08-20T10:00:00.000Z"),
+      bad: new Date(Number.NaN),
+    });
+
+    expect(store.getSnapshot()).toEqual({ good: "2026-08-20T10:00:00.000Z" });
+  });
+
   test("a __proto__ key is stored as data, not swallowed by the prototype", () => {
     store.setEmbeddedData({ ["__proto__"]: "value" });
 

--- a/packages/react-native/src/lib/survey/tests/embedded-data.test.ts
+++ b/packages/react-native/src/lib/survey/tests/embedded-data.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
+
+// The guards log through Logger; mocked so refused inputs don't spray the test output.
+vi.mock("@/lib/common/logger", () => ({
+  Logger: { getInstance: vi.fn(() => ({ error: vi.fn(), debug: vi.fn() })) },
+}));
+
+type TSetInput = Parameters<EmbeddedDataStore["setEmbeddedData"]>[0];
+
+describe("EmbeddedDataStore", () => {
+  let store: EmbeddedDataStore;
+
+  beforeEach(() => {
+    store = EmbeddedDataStore.getInstance();
+    store.clearEmbeddedData();
+  });
+
+  test("merges instead of replacing: setting one key keeps the others", () => {
+    store.setEmbeddedData({ plan: "pro", screen: "product" });
+    store.setEmbeddedData({ screen: "checkout" });
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro", screen: "checkout" });
+  });
+
+  test("null drops the key", () => {
+    store.setEmbeddedData({ plan: "pro", screen: "product" });
+    store.setEmbeddedData({ screen: null });
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro" });
+  });
+
+  // One keystroke away from `null` and the opposite behavior: a host that builds the object from
+  // its own state passes every field unconditionally, so a key absent on the current screen
+  // arrives as `undefined` and must not clear what a previous screen set.
+  test("undefined is a no-op — does not set, does not drop", () => {
+    store.setEmbeddedData({ plan: "pro" });
+    store.setEmbeddedData({ plan: undefined, screen: undefined });
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro" });
+  });
+
+  test("clearEmbeddedData(key) removes one key, clearEmbeddedData() removes everything", () => {
+    store.setEmbeddedData({ plan: "pro", screen: "product", seats: 4 });
+
+    store.clearEmbeddedData("screen");
+    expect(store.getSnapshot()).toEqual({ plan: "pro", seats: 4 });
+
+    store.clearEmbeddedData();
+    expect(store.getSnapshot()).toEqual({});
+  });
+
+  test("last write wins per key", () => {
+    store.setEmbeddedData({ plan: "free" });
+    store.setEmbeddedData({ plan: "pro" });
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro" });
+  });
+
+  test("snapshot is a detached copy: later writes do not reach an earlier snapshot", () => {
+    // The freeze that "a value set after a survey is displayed does not change that response"
+    // rests on — `SurveyWebView` holds exactly this object for the life of the survey.
+    store.setEmbeddedData({ plan: "pro" });
+    const snapshot = store.getSnapshot();
+
+    store.setEmbeddedData({ plan: "enterprise", extra: "later" });
+
+    expect(snapshot).toEqual({ plan: "pro" });
+  });
+
+  test("booleans survive and dates serialize to ISO 8601, which the ingest contract accepts", () => {
+    store.setEmbeddedData({
+      isTrial: true,
+      signedUpAt: new Date("2026-08-20T10:00:00.000Z"),
+    });
+
+    expect(store.getSnapshot()).toEqual({
+      isTrial: true,
+      signedUpAt: "2026-08-20T10:00:00.000Z",
+    });
+  });
+
+  test("a __proto__ key is stored as data, not swallowed by the prototype", () => {
+    store.setEmbeddedData({ ["__proto__"]: "value" });
+
+    const snapshot = store.getSnapshot();
+    // Read through the descriptor rather than the dot: it proves the key landed as an own DATA
+    // property, which `snapshot.__proto__` cannot distinguish from the inherited accessor.
+    expect(Object.getOwnPropertyDescriptor(snapshot, "__proto__")?.value).toBe(
+      "value",
+    );
+    expect(Object.keys({})).toEqual([]);
+  });
+
+  test("makes no network calls — it is a synchronous memory write", () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    store.setEmbeddedData({ plan: "pro", secret: "value" });
+    store.clearEmbeddedData("secret");
+    store.getSnapshot();
+    store.clearEmbeddedData();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("input guards (never fatal)", () => {
+  let store: EmbeddedDataStore;
+
+  beforeEach(() => {
+    store = EmbeddedDataStore.getInstance();
+    store.clearEmbeddedData();
+  });
+
+  test("setEmbeddedData(null) and (undefined) do not throw into host code and set nothing", () => {
+    store.setEmbeddedData({ plan: "pro" });
+
+    expect(() => {
+      store.setEmbeddedData(null as unknown as TSetInput);
+      store.setEmbeddedData(undefined as unknown as TSetInput);
+    }).not.toThrow();
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro" });
+  });
+
+  test("a primitive argument is refused instead of spreading into junk keys", () => {
+    store.setEmbeddedData("plan" as unknown as TSetInput);
+
+    expect(store.getSnapshot()).toEqual({});
+  });
+
+  test('an array is refused too — typeof [] is "object", but it would spread into numeric junk keys', () => {
+    store.setEmbeddedData(["a", "b"] as unknown as TSetInput);
+
+    expect(store.getSnapshot()).toEqual({});
+  });
+
+  test("clearEmbeddedData(undefined) is a no-op, NOT a full clear — one keystroke from the no-arg overload", () => {
+    store.setEmbeddedData({ plan: "pro", screen: "product" });
+
+    store.clearEmbeddedData(undefined as unknown as string);
+
+    expect(store.getSnapshot()).toEqual({ plan: "pro", screen: "product" });
+  });
+});

--- a/packages/react-native/src/lib/user/tests/user.test.ts
+++ b/packages/react-native/src/lib/user/tests/user.test.ts
@@ -9,6 +9,7 @@ import {
 import { RNConfig } from "@/lib/common/config";
 import { Logger } from "@/lib/common/logger";
 import { tearDown } from "@/lib/common/setup";
+import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
 import { UpdateQueue } from "@/lib/user/update-queue";
 import { logout, setUserId } from "@/lib/user/user";
 
@@ -207,6 +208,72 @@ describe("user.ts", () => {
       );
       expect(tearDown).toHaveBeenCalled();
       expect(result.ok).toBe(true);
+    });
+  });
+
+  /**
+   * The ambient Embedded Data bag survives a survey, so it has to be cleared where identity
+   * changes — otherwise one user's context rides onto the next user's responses on a shared
+   * device. Deliberately NOT cleared on first identification: a host legitimately pushes context
+   * before it knows who the user is.
+   */
+  describe("Embedded Data bag on identity change", () => {
+    const store = (): EmbeddedDataStore => EmbeddedDataStore.getInstance();
+
+    const mockDeps = (currentUserId: string | null): void => {
+      getInstanceConfigMock.mockReturnValue({
+        get: vi
+          .fn()
+          .mockReturnValue({ user: { data: { userId: currentUserId } } }),
+      } as unknown as Promise<RNConfig>);
+      getInstanceLoggerMock.mockReturnValue({
+        debug: vi.fn(),
+        error: vi.fn(),
+      } as unknown as Logger);
+      getInstanceUpdateQueueMock.mockReturnValue({
+        updateUserId: vi.fn(),
+        processUpdates: vi.fn(),
+      } as unknown as UpdateQueue);
+    };
+
+    beforeEach(() => {
+      store().clearEmbeddedData();
+    });
+
+    test("switching to a different userId clears the bag", async () => {
+      mockDeps("existing-user");
+      store().setEmbeddedData({ plan: "pro" });
+
+      await setUserId(mockUserId);
+
+      expect(store().getSnapshot()).toEqual({});
+    });
+
+    test("identifying for the first time keeps the bag", async () => {
+      mockDeps(null);
+      store().setEmbeddedData({ plan: "pro" });
+
+      await setUserId(mockUserId);
+
+      expect(store().getSnapshot()).toEqual({ plan: "pro" });
+    });
+
+    test("setting the same userId again keeps the bag", async () => {
+      mockDeps(mockUserId);
+      store().setEmbeddedData({ plan: "pro" });
+
+      await setUserId(mockUserId);
+
+      expect(store().getSnapshot()).toEqual({ plan: "pro" });
+    });
+
+    test("logout clears the bag", async () => {
+      mockDeps(mockUserId);
+      store().setEmbeddedData({ plan: "pro" });
+
+      await logout();
+
+      expect(store().getSnapshot()).toEqual({});
     });
   });
 });

--- a/packages/react-native/src/lib/user/user.ts
+++ b/packages/react-native/src/lib/user/user.ts
@@ -1,6 +1,7 @@
 import { RNConfig } from "@/lib/common/config";
 import { Logger } from "@/lib/common/logger";
 import { tearDown } from "@/lib/common/setup";
+import { EmbeddedDataStore } from "@/lib/survey/embedded-data";
 import { UpdateQueue } from "@/lib/user/update-queue";
 import { type ApiErrorResponse, okVoid, type Result } from "@/types/error";
 
@@ -27,6 +28,12 @@ export const setUserId = async (
       "Different userId is being set, cleaning up previous user state",
     );
     await tearDown();
+    // An identity switch: the ambient Embedded Data bag may carry the previous user's context
+    // (hashed ids and the like), which must not ride onto the next user's responses. Deliberately
+    // not in tearDown() itself — the setup-error teardown is not an identity switch, and app
+    // context should survive a setup retry. First-time identification (no currentUserId) keeps the
+    // bag too: the host legitimately pushes context before identifying.
+    EmbeddedDataStore.getInstance().clearEmbeddedData();
   }
 
   updateQueue.updateUserId(userId);
@@ -39,5 +46,8 @@ export const logout = async (): Promise<Result<void>> => {
 
   logger.debug("Logging out and cleaning user state");
   await tearDown();
+  // Same identity-switch rule as setUserId above: logout must not let the previous user's ambient
+  // context leak onto whoever uses the app next.
+  EmbeddedDataStore.getInstance().clearEmbeddedData();
   return okVoid();
 };

--- a/packages/react-native/src/types/response.ts
+++ b/packages/react-native/src/types/response.ts
@@ -14,6 +14,20 @@ export type TResponseHiddenFieldValue = Record<
   string | number | string[]
 >;
 
+/**
+ * What the renderer accepts for `hiddenFieldsRecord`: the legacy shape plus the booleans its
+ * Embedded Data ingest contract normalizes (`TIngestableScalar` is `string | number | boolean |
+ * Date`) but that the older types cannot spell. Dates are serialized to ISO 8601 before they get
+ * here, so they arrive as strings.
+ *
+ * Its own type rather than a cast to `TResponseData`: the store really does hold booleans, and an
+ * assertion there would only hide the mismatch from the compiler while the value flows on regardless.
+ */
+export type TIngestedFieldsRecord = Record<
+  string,
+  string | number | boolean | string[] | Record<string, string>
+>;
+
 export interface TResponseUpdate {
   finished: boolean;
   data: TResponseData;

--- a/packages/react-native/src/types/survey.ts
+++ b/packages/react-native/src/types/survey.ts
@@ -1,4 +1,8 @@
-import type { TResponseData, TResponseUpdate } from "@/types/response";
+import type {
+  TIngestedFieldsRecord,
+  TResponseData,
+  TResponseUpdate,
+} from "@/types/response";
 import type { TFileUploadParams, TUploadFileConfig } from "@/types/storage";
 import type { TOverlay } from "./common";
 import type { TWorkspaceStyling } from "./workspace";
@@ -47,7 +51,7 @@ export interface SurveyBaseProps {
   startAtQuestionId?: string;
   clickOutside?: boolean;
   overlay?: TOverlay;
-  hiddenFieldsRecord?: TResponseData;
+  hiddenFieldsRecord?: TIngestedFieldsRecord;
   shouldResetQuestionId?: boolean;
   fullSizeCards?: boolean;
 }


### PR DESCRIPTION
## What & why

**Was:** `track()` takes a name and nothing else, so the only way to get context onto an app-survey response was to declare a field and have the respondent type it. **Now:** the host app can attach context to future responses without tying it to a trigger.

```ts
import { setEmbeddedData, clearEmbeddedData } from "@formbricks/react-native";

setEmbeddedData({ screen: "checkout", plan: "pro" });
setEmbeddedData({ screen: null });   // remove one key
clearEmbeddedData("plan");           // same, explicitly
clearEmbeddedData();                 // everything — logout, hard context switch
```

Mirrors js-core's `setEmbeddedData` key for key (formbricks/formbricks#8989), so web and mobile behave identically.

- **Merge, never replace.** Refreshing a volatile field cannot wipe a stable one. `null` removes a key; **`undefined` is a no-op, not an eviction** — a host building the object from its own state passes every field unconditionally, and a key absent on the current screen must not cost the bag its value. Only a literal zero-argument `clearEmbeddedData()` clears everything.
- **In-memory, never persisted.** Not `RNConfig` — persisting would blur the Embedded Data ↔ contact-attribute boundary and create a PII-at-rest surface. Cleared on an identity *switch* and on `logout`, so one user's context cannot ride onto the next user's responses on a shared device; kept on first identification, because a host legitimately pushes context before it knows who the user is.
- **Snapshot at display, then frozen.** A later write reaches the next response, never the one on screen.
- **Dumb pipe.** The bag rides the props payload that already exists, under `hiddenFieldsRecord` — no new bridge message, deliberately. It goes out raw: the ingest contract (allow-list, coercion, `locked`, size caps) lives in the renderer, and the server re-runs all of it. Filtering here would ship a second copy of those rules for four mobile SDKs to drift from.
- **Two things are refused at the door**, because this SDK serializes values itself where js-core does not: an **invalid `Date`** (`toISOString()` throws a `RangeError`, and `getSnapshot()` runs inside the display effect — one bad value would cost the survey, not the field), and a non-object argument. Both are logged and skipped, never thrown.
- **A debug-level success trace**, because the bag is otherwise invisible — memory-only, no getter — so a host wiring this up got no confirmation until a survey happened to display. Mirrors js-core (formbricks/formbricks#9091). **Keys only, never values**: the documented use of this bag includes hashed identity fields.

**Where to look:** `src/lib/survey/embedded-data.ts` (the store, every lifetime rule, and the trace) · `src/components/survey-web-view.tsx` (why the snapshot is in state, not read during render) · `src/lib/user/user.ts` (identity-switch clearing).

Requires the renderer change in formbricks/formbricks#9067 for the auto-capture half; this PR is independent of it and needs no server change.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2472/mobile-sdk-parity-for-embedded-data-one-batched-release-per-sdk

## How this was tested

- `pnpm test` ✅ 20 files / **195 tests** · `pnpm check-types` ✅ 3/3 tasks · `pnpm lint` ✅ clean (biome: 0 errors, 0 info)
- `src/lib/survey/tests/embedded-data.test.ts` (20) covers merge, `null` removal, the `undefined` no-op, single-key clear, clear-all, last-write-wins, the detached snapshot, boolean and Date→ISO serialization, the invalid-Date guard (two cases), the `__proto__` key landing as own data, no network, every input guard (`null`, a primitive, an array, `clearEmbeddedData(undefined)`), and the five debug-trace cases below.
- `user.test.ts` gains four: switch clears · first identification keeps · same id keeps · logout clears. **Mutation-checked** — commenting out both `clearEmbeddedData()` calls in `src/lib/user/user.ts` turns "switching to a different userId clears the bag" and "logout clears the bag" red, and leaves the two "keeps" cases green.
- The invalid-Date guard is **mutation-checked** too: forcing the condition false turns exactly its two tests red.
- `survey-web-view-harness.test.ts` gains one pinning that `hiddenFieldsRecord` survives JSON serialization into the props blob under the name the renderer reads, including a key the survey does not declare (the SDK must not filter).

<details><summary>Why the snapshot lives in state</summary>

`renderHtml({...})` is computed inline in the render pass and its result is the WebView's `source`. Reading the mutable bag there would mean a `setEmbeddedData` during an open survey changes the html string — and a changed `source` reloads the WebView, losing the respondent's answers. So the bag is copied into state in the same update as `setShowSurvey(true)`, which is also the delay-aware moment js-core snapshots at (it builds its own bag inside the delay timeout, not before it).

</details>

<details><summary>Review follow-ups</summary>

**Commit `4a419f0`.** Two findings, both real:

1. *Invalid `Date` reached storage.* `new Date("nope") instanceof Date` is `true`, so it passed the input type; `toISOString()` then throws `RangeError: Invalid time value` from `getSnapshot()`, which runs inside the display effect. Now refused at the door with a log. Deliberately absent from js-core, where the `Date` object goes straight to the renderer and is coerced there — serializing to ISO 8601 is this SDK's own step, so the hazard is this SDK's too.
2. *`getSnapshot()` asserted booleans away.* It returned `TResponseData` via `as`, and that type cannot spell `boolean` — which the bag holds and the renderer's contract accepts (`TIngestableScalar = string | number | boolean | Date`). Replaced with a new `TIngestedFieldsRecord` that says what actually travels; the cast is gone and the mirrored `hiddenFieldsRecord` prop widened to match the renderer it mirrors.

A third finding — move the harness test under `src/lib/**/tests/` — was withdrawn on discussion: that guideline covers domain modules under `src/lib/`, `renderHtml` is a component export, and `src/components/tests/` (both files) pre-dates this PR.

**Commit `36aa96e`.** The debug success trace, mirroring formbricks/formbricks#9091:

```
setEmbeddedData: set [plan, hashed_email] — the bag now holds [plan, hashed_email]. Keys land on a response only if the survey declares them as ingested Embedded Data fields.
setEmbeddedData: set [screen], removed [plan] — the bag now holds [screen]. …
clearEmbeddedData: removed "plan" — the bag now holds [screen]
clearEmbeddedData: cleared the whole bag (2 keys)
```

Stricter gate than on web: js-core prints behind `?formbricksDebug=true`, while this SDK's only `logger.configure` call sets `logLevel: __DEV__ ? "debug" : "error"` — a release build cannot print it at all. A key skipped by the invalid-Date guard appears in neither list: it was not set and nothing was removed for it, and the error line already names it.

Five tests, and the no-values rule is **mutation-checked**: swapping `set.join` for `[...this.data.values()].join` turns exactly three of them red, including the one asserting a `hashed_email` value never reaches the line.

</details>

## Breaking changes

None. Two new named exports and one new optional key in a payload the renderer already accepts. `track()`, `setUserId()`, `setAttribute(s)()`, `setLanguage()` and `logout()` are untouched in signature; `logout()` and an identity-switching `setUserId()` additionally clear the new in-memory bag, which did not exist before.

`SurveyContainerProps.hiddenFieldsRecord` widens from `TResponseData` to `TIngestedFieldsRecord` — a superset, and the prop had no other reader before this PR, so nothing that compiled before stops compiling.

## QA / Test Plan

**How to test**

- [ ] Declare an Embedded Data / hidden field `plan` on an app survey. In the host app call `setEmbeddedData({ plan: "pro" })`, then `track()` the survey's action → the response shows `plan = pro`.
- [ ] Call `setEmbeddedData({ plan: "pro" })` then `setEmbeddedData({ screen: "checkout" })` → the response carries **both**. Merge, not replace.
- [ ] `setEmbeddedData({ plan: null })` → `plan` is absent from the next response, `screen` is still there.
- [ ] `clearEmbeddedData()` with no argument → the next response carries none of the fields.
- [ ] `setEmbeddedData({ plan: undefined })` after setting `plan: "pro"` → the next response still has `plan = pro`. This is the one that is easy to get backwards.
- [ ] **In a debug build**, watch the console while calling `setEmbeddedData` / `clearEmbeddedData` → each call logs the keys it set or removed and what the bag now holds. **No values appear in any line** — try it with a value you would not want logged.
- [ ] **In a release build**, the same calls log nothing.
- [ ] Open a survey, then call `setEmbeddedData({ plan: "enterprise" })` while it is on screen, then finish it → the response records the value from when the survey **appeared**, and the survey does not reload or lose answers.
- [ ] Same with a survey that has a delay: set the value during the delay → the response carries the value as of when it actually appeared.
- [ ] Send a key the survey does not declare → the response is created normally without it, and the WebView console logs that the key was dropped. Nothing throws.
- [ ] `setUserId("a")` → `setEmbeddedData({ plan: "pro" })` → `setUserId("b")` → survey → the response carries **no** `plan`.
- [ ] `logout()` after setting values → the next response carries none of them.
- [ ] Kill and relaunch the app without re-pushing → the next response carries nothing. The bag is memory-only by design.
- [ ] `setEmbeddedData({ signedUpAt: new Date("nope") })` → logged and skipped, **and the survey still displays**. This is the one that would fail loudly if the guard were missing.
- [ ] A valid `Date` → arrives on the response as an ISO 8601 string and reads back as a date on a `date`-typed field.
- [ ] `setEmbeddedData(undefined)` or `setEmbeddedData(["a","b"])` from host code → logged and skipped, app does not crash.

**Preconditions / test data**

- An app survey with at least one ingested field (a hidden field works), the SDK pointed at an instance serving the current `surveys.umd.cjs`, and the playground app or a host app. Response card is the readout.

**Risks & regressions**

- The WebView `source` string now includes one more key. If the snapshot were read during render instead of from state, an in-flight `setEmbeddedData` would reload the WebView — covered above; worth re-checking the "set a value while a survey is open" step on a real device.
- `logout()` and identity-switching `setUserId()` now also clear the bag. Nothing else observes it, so no other behaviour changes.
- The new trace prints field **names** in debug builds. That is intended and matches js-core, but it is the one new thing reaching a console — the no-values rule is what keeps it safe, and it is asserted rather than assumed.

**Migrations / env / cutover**

- none. Ships as a normal SDK release; no server or config change.

---
_Generated by [Claude Code](https://claude.ai/code/session_018L6PrECN38Jbe1FEdFccTz)_